### PR TITLE
backend_ros: P08 Unknown types NOT_SET (PASS)

### DIFF
--- a/harness/backends/backend_ros/src/ops.rs
+++ b/harness/backends/backend_ros/src/ops.rs
@@ -356,11 +356,20 @@ fn exec_describe_param(
                 an.cmp(bn)
             });
 
+            // P08: Emit param_type for unknown/known parameters.
+            // If the parameter is unknown, ROS returns a descriptor with type 0 (NOT_SET).
+            let param_type_str = response
+                .descriptors
+                .first()
+                .map(|d| param_type_to_string(d.type_))
+                .unwrap_or("NOT_SET");
+
             w.emit(json!({
                 "type": "param_describe_response",
                 "scenario_id": scenario_id,
                 "node": "/oracle_backend_ros",
                 "name": name,
+                "param_type": param_type_str,
                 "detail": {
                     "descriptors": descriptors
                 }
@@ -448,6 +457,21 @@ fn parameter_descriptor_to_json(d: &ParameterDescriptor) -> serde_json::Value {
             "step": r.step
         })).collect::<Vec<_>>(),
     })
+}
+
+fn param_type_to_string(t: u8) -> &'static str {
+    match t {
+        1 => "bool",
+        2 => "integer",
+        3 => "double",
+        4 => "string",
+        5 => "byte_array",
+        6 => "bool_array",
+        7 => "integer_array",
+        8 => "double_array",
+        9 => "string_array",
+        _ => "NOT_SET",
+    }
 }
 
 fn exec_send_goal(w: &mut EventWriter, scenario_id: &str, op: &Op) -> Result<(), BackendError> {


### PR DESCRIPTION
## Scenario
- P08 — Unknown types NOT_SET

## Change
Fixes backend_ros trace evidence for DescribeParameters by including `param_type`
in `param_describe_response`.

Adds a minimal `param_type_to_string` helper mapping ROS parameter type codes to
stable strings and defaults to `NOT_SET` for unknown/untyped parameters.

## Expected vs observed (harness)
Expected:
- Describing an unknown parameter emits `param_type: "NOT_SET"`.

Observed:
- P03: PASS
- P04: PASS
- P06: PASS
- P08: PASS
- P12: PASS
- Other scenarios: SKIP as before

## Commands run
- `python3 harness/scripts/validate_bundles.py`
- `cd harness && ./scripts/run_harness.sh scenarios/scenarios_P.json`

## Notes
- No normative spec/doc changes.
- No CI/provenance gate changes.
- Diff scoped to backend evidence only.
